### PR TITLE
Adding Contributing.md that is now required for OSS project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,3 @@
-*This is a suggested `CONTRIBUTING.md` file template for use by open sourced Salesforce projects. The main goal of this file is to make clear the intents and expectations that end-users may have regarding this project and how/if to engage with it. Adjust as needed (especially look for `{project_slug}` which refers to the org and repo name of your project) and remove this paragraph before committing to your repo.*
-
 # Contributing Guide For @salesforce/eslint-plugin-lwc-mobile
 
 This page lists the operational governance model of this project, as well as the recommendations and requirements for how to best contribute to @salesforce/eslint-plugin-lwc-mobile. We strive to obey these as best as possible. As always, thanks for contributing – we hope these guidelines make it easier and shed some light on our approach and processes.


### PR DESCRIPTION
Contributing.md is now a requirement for OSS project.

This [template](https://github.com/salesforce/oss-template/blob/main/CONTRIBUTING.md) was used and fitted for this project.