### PR TITLE
Minor and patch dependency updates - group in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,16 @@ updates:
       directory: '/'
       schedule:
           interval: 'monthly'
-          day: 'monday'
-          time: '08:00'
-          timezone: 'America/Los_Angeles'
       versioning-strategy: 'increase'
       labels:
           - 'dependencies'
+      groups:
+          # Group all minor and patch dependency updates together.
+          minor-and-patch:
+              applies-to: version-updates
+              update-types:
+                  - 'minor'
+                  - 'patch'
       open-pull-requests-limit: 5
       pull-request-branch-name:
           separator: '-'


### PR DESCRIPTION
### What does this PR do?
To cut down on the noise of PRs, group all minor and patch dependency updates together, so they can be evaluated in one shot.

### What issues does this PR fix or reference?
Large numbers of dependabot PRs.