### PR TITLE
Update 'typescript-eslint/utils' to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
         "/dist"
     ],
     "dependencies": {
-        "@graphql-eslint/eslint-plugin": "^3.20.1"
+        "@graphql-eslint/eslint-plugin": "^3.20.1",
+        "@typescript-eslint/utils": "^7.8.0"
     },
     "devDependencies": {
         "@commitlint/cli": "^19.5.0",
@@ -76,7 +77,6 @@
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@typescript-eslint/parser": "^7.18.0",
         "@typescript-eslint/rule-tester": "^7.8.0",
-        "@typescript-eslint/utils": "^7.8.0",
         "conventional-changelog-conventionalcommits": "^8.0.0",
         "eslint": "^8.57.0",
         "eslint-plugin-eslint-plugin": "^6.3.1",

--- a/src/rules/graphql/no-more-than-100-fields.ts
+++ b/src/rules/graphql/no-more-than-100-fields.ts
@@ -57,7 +57,7 @@ export const rule: GraphQLESLintRule = {
                         query OpportunityExample {
                             uiapi {
                                 query {
-                                    Opportunity {
+                                    Opportunity(first: 201) {
                                         edges {
                                             node {
                                                 Id


### PR DESCRIPTION
### What does this PR do?

- Update 'typescript-eslint/utils' from devDependency to dependency
- Update incorrect sample code for 'more-than-100-field' rule

### What issues does this PR fix or reference?

- When `eslint-plugin-lwc-mobile` is installed as devDependency, the 'typescript-eslint/utils' would show up in 'node_modules'
